### PR TITLE
Cloning `development` repo for testing

### DIFF
--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -28,6 +28,10 @@ jobs:
       # At 2025-05 a new token was added in the gitgub-action secrets. This token will expire ~05-2026.
       # When that happens, generate a new one following the documentation:
       # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+      # More specifically:
+      #  - go to https://github.com/settings/personal-access-tokens
+      #  - create a (fine-grained) token for ECA-D/development
+      #  - the fine grained token should have  "Read access to metadata" and "Read and Write access to code"
       - name: checkout development repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/checkout@v3
 
       # At 2025-05 a new token was added in the gitgub-action secrets. This token will expire ~05-2026.
-      # When that happens, generate a new one following the documentation: 
+      # When that happens, generate a new one following the documentation:
       # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-      - name: checkout development
+      - name: checkout development repository
         uses: actions/checkout@v3
         with:
           repository: ECA-D/development
@@ -36,10 +36,6 @@ jobs:
           path: development
           ref: main
           fetch-depth: 0
-      - name: Run development tests
-        run: |
-          which python
-          python development/test.py
       - uses: conda-incubator/setup-miniconda@v3
         if: matrix.os == 'ubuntu-latest'
         with:
@@ -56,8 +52,12 @@ jobs:
         run: bash install_step1_R.sh
       - name: run_test
         run: bash run_minimal_test.sh
-      - name: conda list
-        run: conda list
+      - name: Run development tests
+        run: |
+          which python
+          python development/test.py
 
+      - name: List full installation of the conda environment
+        run: conda list
       - name: "completed"
-        run: echo 'All complete, successfull'
+        run: echo 'All complete, successful'

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -25,15 +25,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      # Access needs to be granted later
-      #   - name: checkout development
-      #     uses: actions/checkout@v3
-      #     with:
-      #       repository: ECA-D/development
-      #       ssh-key: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      #       path: development
-      #       ref: master
-      #       fetch-depth: 0
+        # Access needs to be granted later
+        - name: checkout development
+          uses: actions/checkout@v3
+          with:
+            repository: ECA-D/development
+            ssh-key: ${{ secrets.development_secret_token }}
+            path: development
+            ref: main
+            fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v3
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -36,7 +36,10 @@ jobs:
           path: development
           ref: main
           fetch-depth: 0
-
+      - name: Run development tests
+        run: |
+          which python
+          python development/test.py
       - uses: conda-incubator/setup-miniconda@v3
         if: matrix.os == 'ubuntu-latest'
         with:

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ECA-D/development
-          ssh-key: ${{ secrets.development_secret_token }}
+          ssh-key: ${{ secrets.DEVELOPMENT_SECRET_TOKEN }}
           path: development
           ref: main
           fetch-depth: 0

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -26,14 +26,14 @@ jobs:
         uses: actions/checkout@v3
 
         # Access needs to be granted later
-        - name: checkout development
-          uses: actions/checkout@v3
-          with:
-            repository: ECA-D/development
-            ssh-key: ${{ secrets.development_secret_token }}
-            path: development
-            ref: main
-            fetch-depth: 0
+      - name: checkout development
+        uses: actions/checkout@v3
+        with:
+          repository: ECA-D/development
+          ssh-key: ${{ secrets.development_secret_token }}
+          path: development
+          ref: main
+          fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v3
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-        # Access needs to be granted later
+      # At 2025-05 a new token was added in the gitgub-action secrets. This token will expire ~05-2026.
+      # When that happens, generate a new one following the documentation: 
+      # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
       - name: checkout development
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -28,13 +28,21 @@ jobs:
       # At 2025-05 a new token was added in the gitgub-action secrets. This token will expire ~05-2026.
       # When that happens, generate a new one following the documentation: 
       # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+      # - name: checkout development
+      #   uses: actions/checkout@v3
+      #   with:
+      #     repository: ECA-D/development
+      #     ssh-key: ${{ secrets.DEVELOPMENT_SECRET_TOKEN }}
+      #     path: development
+      #     ref: main
+      #     fetch-depth: 0
       - name: checkout development
         uses: actions/checkout@v3
         with:
-          repository: ECA-D/development
-          ssh-key: ${{ secrets.DEVELOPMENT_SECRET_TOKEN }}
-          path: development
-          ref: main
+          repository: JoranAngevaare/test_actions
+          ssh-key: ${{ secrets.test_actions_test_token }}
+          path: test
+          ref: master
           fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -32,7 +32,7 @@ jobs:
       #   uses: actions/checkout@v3
       #   with:
       #     repository: ECA-D/development
-      #     ssh-key: ${{ secrets.DEVELOPMENT_SECRET_TOKEN }}
+      #     token: ${{ secrets.DEVELOPMENT_SECRET_TOKEN }}
       #     path: development
       #     ref: main
       #     fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: JoranAngevaare/test_actions
-          ssh-key: ${{ secrets.test_actions_test_token }}
+          token: ${{ secrets.test_actions_test_token }}
           path: test
           ref: master
           fetch-depth: 0

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -28,21 +28,13 @@ jobs:
       # At 2025-05 a new token was added in the gitgub-action secrets. This token will expire ~05-2026.
       # When that happens, generate a new one following the documentation: 
       # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-      # - name: checkout development
-      #   uses: actions/checkout@v3
-      #   with:
-      #     repository: ECA-D/development
-      #     token: ${{ secrets.DEVELOPMENT_SECRET_TOKEN }}
-      #     path: development
-      #     ref: main
-      #     fetch-depth: 0
       - name: checkout development
         uses: actions/checkout@v3
         with:
-          repository: JoranAngevaare/test_actions
-          token: ${{ secrets.test_actions_test_token }}
-          path: test
-          ref: master
+          repository: ECA-D/development
+          token: ${{ secrets.DEVELOPMENT_SECRET_TOKEN }}
+          path: development
+          ref: main
           fetch-depth: 0
 
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/build_environment.yml
+++ b/.github/workflows/build_environment.yml
@@ -31,7 +31,7 @@ jobs:
       # More specifically:
       #  - go to https://github.com/settings/personal-access-tokens
       #  - create a (fine-grained) token for ECA-D/development
-      #  - the fine grained token should have  "Read access to metadata" and "Read and Write access to code"
+      #  - the fine grained token should have "Read access to metadata" and "Read and Write access to code"
       - name: checkout development repository
         uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ conda create -n eobs_r
 ```
 At the time of writing, we focused on python 3.11 for now, but alternative python versions might be supported in the future.
 
-### 3. Install requirements'
+### 3. Install requirements
 Finally install all the required libraries, which is a mix of `conda` and pure `R` libraries.
 ```bash
 git clone https://github.com/ECA-D/eobs_environment .


### PR DESCRIPTION
## cloning a private repo into this repo during testing
In this PR, we showcase how to clone a peivate repo `development` into this repo during testing.

The aim is to clone `eobs`, and `eobs_batch` and run a full test of the workflow in this repository. First, we demonstrate the functionality, security, pros, and cons.

### This PR
In this PR, we add a two steps to the `build_environment.yml`:
 1. Clone the (private) repo: https://github.com/ECA-D/development.
 2. Run a test called `test.py` from https://github.com/ECA-D/development

We call step 1. prior to building the actual software environment as this step is really quick, while the building of the environment takes ~5-6 minutes. So if step 1. fails, we would prefer to know that before building the environment.

### Requirements for token
We added a fine-grained [personal access token (PAT) ](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for  https://github.com/ECA-D/development. The token added in https://github.com/ECA-D/eobs_environment/settings/secrets/actions, should have  "Read access to metadata" and "Read and Write access to code".

